### PR TITLE
Implement passthrough parser

### DIFF
--- a/passthrough/go.mod
+++ b/passthrough/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require github.com/frankban/quicktest v1.14.6
 
 require (
+	github.com/yuin/goldmark v1.6.0
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect

--- a/passthrough/go.sum
+++ b/passthrough/go.sum
@@ -10,3 +10,5 @@ github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/yuin/goldmark v1.6.0 h1:boZcn2GTjpsynOsC0iJHnBWa4Bi0qzfJjthwauItG68=
+github.com/yuin/goldmark v1.6.0/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/passthrough/passthrough.go
+++ b/passthrough/passthrough.go
@@ -70,21 +70,12 @@ func NewPassthroughInline(segment text.Segment) *PassthroughInline {
 	}
 }
 
-// IsRaw implements Node.IsRaw.
-func (n *PassthroughInline) IsRaw() bool {
-	return true
-}
-
-// Inline implements Inline.Inline.
-func (n *PassthroughInline) Inline() {
-}
-
 // Text implements Node.Text.
 func (n *PassthroughInline) Text(source []byte) []byte {
 	return n.Segment.Value(source)
 }
 
-// Dump implements Node.Dump .
+// Dump implements Node.Dump.
 func (n *PassthroughInline) Dump(source []byte, level int) {
 	indent := strings.Repeat("    ", level)
 	fmt.Printf("%sPassthroughInline {\n", indent)

--- a/passthrough/passthrough.go
+++ b/passthrough/passthrough.go
@@ -2,9 +2,12 @@ package passthrough
 
 import (
 	"bytes"
+	// FIXME: remove fmt
+	"fmt"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
 	"github.com/yuin/goldmark/text"
 	"github.com/yuin/goldmark/util"
 )
@@ -14,31 +17,8 @@ type delimiters struct {
 	Close string
 }
 
-type inlinePassthroughParser struct {
-	PassthroughDelimiters []delimiters
-}
-
-// NewInlinePassthroughParser return a new InlineParser that parses inline pass through.
-func NewInlinePassthroughParser(ds []delimiters) parser.InlineParser {
-	return &inlinePassthroughParser{
-		PassthroughDelimiters: ds,
-	}
-}
-
-// `Parse` will be executed once for each character that is in this list of
-// allowed trigger characters. Our parse function needs to do some additional
-// checks because Trigger only works for single-byte delimiters.
-func (s *inlinePassthroughParser) Trigger() []byte {
-	var firstBytes []byte
-
-	for _, d := range s.PassthroughDelimiters {
-		firstBytes = append(firstBytes, d.Open[0])
-		if d.Open[0] != d.Close[0] {
-			firstBytes = append(firstBytes, d.Close[0])
-		}
-	}
-
-	return firstBytes
+type parserWithDelimiters interface {
+	delimiters() []delimiters
 }
 
 // Determine if a byte array starts with a given string
@@ -52,14 +32,48 @@ func startsWith(b []byte, s string) bool {
 
 // Determine if the input slice starts with a full valid opening delimiter.
 // If so, returns the delimiter struct, otherwise returns nil.
-func (s *inlinePassthroughParser) GetFullOpeningDelimiter(line []byte) *delimiters {
-	for _, d := range s.PassthroughDelimiters {
+func GetFullOpeningDelimiter(s parserWithDelimiters, line []byte) *delimiters {
+	for _, d := range s.delimiters() {
 		if startsWith(line, d.Open) {
 			return &d
 		}
 	}
 
 	return nil
+}
+
+// Return an array of bytes containing the first byte of each opening
+// delimiter. Used to populate the trigger list for inline and block parsers.
+// `Parse` will be executed once for each character that is in this list of
+// allowed trigger characters. Our parse function needs to do some additional
+// checks because Trigger only works for single-byte delimiters.
+func OpenersFirstByte(s parserWithDelimiters) []byte {
+	var firstBytes []byte
+	for _, d := range s.delimiters() {
+		firstBytes = append(firstBytes, d.Open[0])
+	}
+	return firstBytes
+}
+
+// ---- Inline Parser ----
+
+type inlinePassthroughParser struct {
+	PassthroughDelimiters []delimiters
+}
+
+// Implements parserWithDelimiters for inlinePassthroughParser
+func (s *inlinePassthroughParser) delimiters() []delimiters {
+	return s.PassthroughDelimiters
+}
+
+func NewInlinePassthroughParser(ds []delimiters) parser.InlineParser {
+	return &inlinePassthroughParser{
+		PassthroughDelimiters: ds,
+	}
+}
+
+func (s *inlinePassthroughParser) Trigger() []byte {
+	return OpenersFirstByte(s)
 }
 
 func (s *inlinePassthroughParser) Parse(parent ast.Node, block text.Reader, pc parser.Context) ast.Node {
@@ -69,7 +83,7 @@ func (s *inlinePassthroughParser) Parse(parent ast.Node, block text.Reader, pc p
 	// of multiple triggers with parser.Context state saved between calls.
 	line, startSegment := block.PeekLine()
 
-	fencePair := s.GetFullOpeningDelimiter(line)
+	fencePair := GetFullOpeningDelimiter(s, line)
 	// fencePair == nil can happen if only the first byte of an opening delimiter
 	// matches, but it is not the complete opening delimiter. The trigger causes
 	// this Parse function to execute, but the trigger interface is limited to
@@ -105,6 +119,156 @@ func (s *inlinePassthroughParser) Parse(parent ast.Node, block text.Reader, pc p
 	}
 }
 
+// ---- Block Parser ----
+
+// A PassthroughBlock struct represents a fenced block of raw text to pass
+// through unchanged.
+// There is no built-in "raw text block" node in goldmark, and the closest
+// thing is a code block, which emits `<pre><code>` tags. So we need a new
+// node and a new block renderer.
+type PassthroughBlock struct {
+	ast.BaseBlock
+}
+
+// IsRaw implements Node.IsRaw.
+func (n *PassthroughBlock) IsRaw() bool {
+	return true
+}
+
+// Dump implements Node.Dump .
+func (n *PassthroughBlock) Dump(source []byte, level int) {
+	ast.DumpHelper(n, source, level, nil, nil)
+}
+
+// KindPassthroughBlock is a NodeKind of the PassthroughBlock node.
+var KindPassthroughBlock = ast.NewNodeKind("PassthroughBlock")
+
+// Kind implements Node.Kind.
+func (n *PassthroughBlock) Kind() ast.NodeKind {
+	return KindPassthroughBlock
+}
+
+// NewPassthroughBlock return a new PassthroughBlock node.
+func NewPassthroughBlock() *PassthroughBlock {
+	return &PassthroughBlock{
+		BaseBlock: ast.BaseBlock{},
+	}
+}
+
+// Block parsing happens across different interface methods, and the initial
+// Open detects the fence pair to use by its opening delimiter. This needs to
+// be preserved for the Continue and Close methods to have access to the
+// corresponding closing delimiter.
+var passthroughParserStateKey = parser.NewContextKey()
+
+type passthroughParserState struct {
+	DetectedDelimiters *delimiters
+}
+
+type blockPassthroughParser struct {
+	PassthroughDelimiters []delimiters
+}
+
+// Implements parserWithDelimiters for blockPassthroughParser
+func (b *blockPassthroughParser) delimiters() []delimiters {
+	return b.PassthroughDelimiters
+}
+
+func NewBlockPassthroughParser(ds []delimiters) parser.BlockParser {
+	return &blockPassthroughParser{
+		PassthroughDelimiters: ds,
+	}
+}
+
+func (b *blockPassthroughParser) Trigger() []byte {
+	return OpenersFirstByte(b)
+}
+
+func (b *blockPassthroughParser) Open(parent ast.Node, reader text.Reader, pc parser.Context) (ast.Node, parser.State) {
+	line, segment := reader.PeekLine()
+	fmt.Println("line: ", string(line))
+	fencePair := GetFullOpeningDelimiter(b, line)
+	// fencePair == nil can happen if only the first byte of an opening delimiter
+	// matches, but it is not the complete opening delimiter.
+	if fencePair == nil {
+		return nil, parser.NoChildren
+	}
+	node := NewPassthroughBlock()
+	pc.Set(passthroughParserStateKey, &passthroughParserState{DetectedDelimiters: fencePair})
+
+	fmt.Println("[open] appending segment: ", string(segment.Value(reader.Source())))
+	node.Lines().Append(segment)
+	reader.Advance(segment.Len() - 1)
+	return node, parser.NoChildren
+}
+
+func (b *blockPassthroughParser) Continue(node ast.Node, reader text.Reader, pc parser.Context) parser.State {
+	// currentState cannot be nil or else Continue was triggered without Open
+	// successfully creating a new node.
+	currentState := pc.Get(passthroughParserStateKey).(*passthroughParserState)
+	fencePair := currentState.DetectedDelimiters
+	line, segment := reader.PeekLine()
+	fmt.Println("[continue] line: ", string(line))
+
+	closingDelimiterPos := bytes.Index(line, []byte(fencePair.Close))
+	if closingDelimiterPos == -1 { // no closer on this line
+		fmt.Println("[continue] no closer")
+		node.Lines().Append(segment)
+		fmt.Println("[continue] appending segment: ", string(segment.Value(reader.Source())))
+		reader.Advance(segment.Len() - 1)
+		return parser.Continue | parser.NoChildren
+	}
+
+	// This segment spans up to and including the closing delimiter.
+	fmt.Println("[continue] found closer")
+	seg := segment.WithStop(segment.Start + closingDelimiterPos + len(fencePair.Close))
+	fmt.Println("[continue] appending segment: ", string(seg.Value(reader.Source())))
+	node.Lines().Append(seg)
+	reader.Advance(closingDelimiterPos + len(fencePair.Close))
+
+	return parser.Close
+}
+
+func (b *blockPassthroughParser) Close(node ast.Node, reader text.Reader, pc parser.Context) {
+}
+
+func (b *blockPassthroughParser) CanInterruptParagraph() bool {
+	return true
+}
+
+func (b *blockPassthroughParser) CanAcceptIndentedLine() bool {
+	return true
+}
+
+type passthroughBlockRenderer struct {
+}
+
+func (r *passthroughBlockRenderer) renderRawBlock(w util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
+	if entering {
+    w.WriteString("\n")
+		l := n.Lines().Len()
+		for i := 0; i < l; i++ {
+			line := n.Lines().At(i)
+			w.WriteString(string(line.Value(source)))
+		}
+    w.WriteString("\n")
+	} else {
+    w.WriteString("\n")
+  }
+	return ast.WalkContinue, nil
+}
+
+// RegisterFuncs implements renderer.NodeRenderer.RegisterFuncs.
+func (r *passthroughBlockRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(KindPassthroughBlock, r.renderRawBlock)
+}
+
+func NewPassthroughBlockRenderer() renderer.NodeRenderer {
+	return &passthroughBlockRenderer{}
+}
+
+// ---- Extension and config ----
+
 type passthrough struct {
 	InlineDelimiters []delimiters
 	BlockDelimiters  []delimiters
@@ -118,7 +282,16 @@ func NewPassthroughWithDelimiters(Inlines []delimiters, Blocks []delimiters) gol
 }
 
 func (e *passthrough) Extend(m goldmark.Markdown) {
-	m.Parser().AddOptions(parser.WithInlineParsers(
-		util.Prioritized(NewInlinePassthroughParser(e.InlineDelimiters), 501),
+	m.Parser().AddOptions(
+		parser.WithBlockParsers(
+			util.Prioritized(NewBlockPassthroughParser(e.BlockDelimiters), 101),
+		),
+		parser.WithInlineParsers(
+			util.Prioritized(NewInlinePassthroughParser(e.InlineDelimiters), 201),
+		),
+	)
+
+	m.Renderer().AddOptions(renderer.WithNodeRenderers(
+		util.Prioritized(NewPassthroughBlockRenderer(), 101),
 	))
 }

--- a/passthrough/passthrough.go
+++ b/passthrough/passthrough.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 )
 
-type delimiters struct {
+type Delimiters struct {
 	Open  string
 	Close string
 }
@@ -33,10 +33,10 @@ type PassthroughInline struct {
 	Segment text.Segment
 
 	// The matched delimiters
-	Delimiters *delimiters
+	Delimiters *Delimiters
 }
 
-func NewPassthroughInline(segment text.Segment, delimiters *delimiters) *PassthroughInline {
+func NewPassthroughInline(segment text.Segment, delimiters *Delimiters) *PassthroughInline {
 	return &PassthroughInline{
 		Segment:    segment,
 		Delimiters: delimiters,
@@ -66,10 +66,10 @@ func (n *PassthroughInline) Kind() ast.NodeKind {
 }
 
 type inlinePassthroughParser struct {
-	PassthroughDelimiters []delimiters
+	PassthroughDelimiters []Delimiters
 }
 
-func NewInlinePassthroughParser(ds []delimiters) parser.InlineParser {
+func NewInlinePassthroughParser(ds []Delimiters) parser.InlineParser {
 	return &inlinePassthroughParser{
 		PassthroughDelimiters: ds,
 	}
@@ -77,7 +77,7 @@ func NewInlinePassthroughParser(ds []delimiters) parser.InlineParser {
 
 // Determine if the input slice starts with a full valid opening delimiter.
 // If so, returns the delimiter struct, otherwise returns nil.
-func GetFullOpeningDelimiter(delims []delimiters, line []byte) *delimiters {
+func GetFullOpeningDelimiter(delims []Delimiters, line []byte) *Delimiters {
 	for _, d := range delims {
 		if startsWith(line, d.Open) {
 			return &d
@@ -92,7 +92,7 @@ func GetFullOpeningDelimiter(delims []delimiters, line []byte) *delimiters {
 // `Parse` will be executed once for each character that is in this list of
 // allowed trigger characters. Our parse function needs to do some additional
 // checks because Trigger only works for single-byte delimiters.
-func OpenersFirstByte(delims []delimiters) []byte {
+func OpenersFirstByte(delims []Delimiters) []byte {
 	var firstBytes []byte
 	containsBackslash := false
 	for _, d := range delims {
@@ -111,7 +111,7 @@ func OpenersFirstByte(delims []delimiters) []byte {
 }
 
 // Determine if the input list of delimiters contains the given delimiter pair
-func ContainsDelimiters(delims []delimiters, toFind *delimiters) bool {
+func ContainsDelimiters(delims []Delimiters, toFind *Delimiters) bool {
 	for _, d := range delims {
 		if d.Open == toFind.Open && d.Close == toFind.Close {
 			return true
@@ -242,7 +242,7 @@ func (r *passthroughBlockRenderer) renderRawBlock(w util.BufWriter, source []byt
 // inline passthrough after it's parsed, looking for nodes whose delimiters
 // match the block delimiters, and splitting the paragraph at that point.
 type passthroughInlineTransformer struct {
-	BlockDelimiters []delimiters
+	BlockDelimiters []Delimiters
 }
 
 var PassthroughInlineTransformer = &passthroughInlineTransformer{}
@@ -330,7 +330,7 @@ func (p *passthroughInlineTransformer) Transform(
 	})
 }
 
-func NewPassthroughInlineTransformer(ds []delimiters) parser.ASTTransformer {
+func NewPassthroughInlineTransformer(ds []Delimiters) parser.ASTTransformer {
 	return &passthroughInlineTransformer{
 		BlockDelimiters: ds,
 	}
@@ -357,13 +357,13 @@ func NewPassthroughBlockRenderer() renderer.NodeRenderer {
 // ---- Extension and config ----
 
 type passthrough struct {
-	InlineDelimiters []delimiters
-	BlockDelimiters  []delimiters
+	InlineDelimiters []Delimiters
+	BlockDelimiters  []Delimiters
 }
 
 func NewPassthroughWithDelimiters(
-	InlineDelimiters []delimiters,
-	BlockDelimiters []delimiters) goldmark.Extender {
+	InlineDelimiters []Delimiters,
+	BlockDelimiters []Delimiters) goldmark.Extender {
 	// The parser executes in two phases:
 	//
 	// Phase 1: parse the input with all delimiters treated as inline, and block delimiters
@@ -371,7 +371,7 @@ func NewPassthroughWithDelimiters(
 	//
 	// Phase 2: transform the parsed AST to split paragraphs at the point of
 	// inline passthroughs with matching block delimiters.
-	combinedDelimiters := make([]delimiters, len(InlineDelimiters)+len(BlockDelimiters))
+	combinedDelimiters := make([]Delimiters, len(InlineDelimiters)+len(BlockDelimiters))
 	copy(combinedDelimiters, BlockDelimiters)
 	copy(combinedDelimiters[len(BlockDelimiters):], InlineDelimiters)
 	return &passthrough{

--- a/passthrough/passthrough.go
+++ b/passthrough/passthrough.go
@@ -1,6 +1,124 @@
 package passthrough
 
-// Foo returns a string.
-func Foo() string {
-	return "foo"
+import (
+	"bytes"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
+)
+
+type delimiters struct {
+	Open  string
+	Close string
+}
+
+type inlinePassthroughParser struct {
+	PassthroughDelimiters []delimiters
+}
+
+// NewInlinePassthroughParser return a new InlineParser that parses inline pass through.
+func NewInlinePassthroughParser(ds []delimiters) parser.InlineParser {
+	return &inlinePassthroughParser{
+		PassthroughDelimiters: ds,
+	}
+}
+
+// `Parse` will be executed once for each character that is in this list of
+// allowed trigger characters. Our parse function needs to do some additional
+// checks because Trigger only works for single-byte delimiters.
+func (s *inlinePassthroughParser) Trigger() []byte {
+	var firstBytes []byte
+
+	for _, d := range s.PassthroughDelimiters {
+		firstBytes = append(firstBytes, d.Open[0])
+		if d.Open[0] != d.Close[0] {
+			firstBytes = append(firstBytes, d.Close[0])
+		}
+	}
+
+	return firstBytes
+}
+
+// Determine if a byte array starts with a given string
+func startsWith(b []byte, s string) bool {
+	if len(b) < len(s) {
+		return false
+	}
+
+	return string(b[:len(s)]) == s
+}
+
+// Determine if the input slice starts with a full valid opening delimiter.
+// If so, returns the delimiter struct, otherwise returns nil.
+func (s *inlinePassthroughParser) GetFullOpeningDelimiter(line []byte) *delimiters {
+	for _, d := range s.PassthroughDelimiters {
+		if startsWith(line, d.Open) {
+			return &d
+		}
+	}
+
+	return nil
+}
+
+func (s *inlinePassthroughParser) Parse(parent ast.Node, block text.Reader, pc parser.Context) ast.Node {
+	// In order to prevent other parser extensions from operating on the text
+	// between passthrough delimiters, we must process the entire inline
+	// passthrough in one execution of Parse. This means we can't use the style
+	// of multiple triggers with parser.Context state saved between calls.
+	line, startSegment := block.PeekLine()
+
+	fencePair := s.GetFullOpeningDelimiter(line)
+	// fencePair == nil can happen if only the first byte of an opening delimiter
+	// matches, but it is not the complete opening delimiter. The trigger causes
+	// this Parse function to execute, but the trigger interface is limited to
+	// matching single bytes.
+	if fencePair == nil {
+		return nil
+	}
+
+	// This roughly follows goldmark/parser/code_span.go
+	block.Advance(len(fencePair.Open))
+	openerSize := len(fencePair.Open)
+	l, pos := block.Position()
+
+	for {
+		line, lineSegment := block.PeekLine()
+		if line == nil {
+			block.SetPosition(l, pos)
+			return ast.NewTextSegment(startSegment.WithStop(startSegment.Start + openerSize))
+		}
+
+		closingDelimiterPos := bytes.Index(line, []byte(fencePair.Close))
+		if closingDelimiterPos == -1 { // no closer on this line
+			block.AdvanceLine()
+			continue
+		}
+
+		// This segment spans from the original starting trigger (including the delimiter)
+		// up to and including the closing delimiter.
+		seg := startSegment.WithStop(lineSegment.Start + closingDelimiterPos + len(fencePair.Close))
+		block.Advance(closingDelimiterPos + len(fencePair.Close))
+
+		return ast.NewRawTextSegment(seg)
+	}
+}
+
+type passthrough struct {
+	InlineDelimiters []delimiters
+	BlockDelimiters  []delimiters
+}
+
+func NewPassthroughWithDelimiters(Inlines []delimiters, Blocks []delimiters) goldmark.Extender {
+	return &passthrough{
+		InlineDelimiters: Inlines,
+		BlockDelimiters:  Blocks,
+	}
+}
+
+func (e *passthrough) Extend(m goldmark.Markdown) {
+	m.Parser().AddOptions(parser.WithInlineParsers(
+		util.Prioritized(NewInlinePassthroughParser(e.InlineDelimiters), 501),
+	))
 }

--- a/passthrough/passthrough.go
+++ b/passthrough/passthrough.go
@@ -144,7 +144,7 @@ func (s *inlinePassthroughParser) Parse(parent ast.Node, block text.Reader, pc p
 			fencePair = GetFullOpeningDelimiter(s.PassthroughDelimiters, line[2:])
 			if fencePair != nil {
 				// Opening delimiter is escaped, return the escaped opener as plain text
-        // So that the characters are not processed again.
+				// So that the characters are not processed again.
 				block.Advance(2 + len(fencePair.Open))
 				return ast.NewTextSegment(startSegment.WithStop(startSegment.Start + len(fencePair.Open) + 2))
 			}

--- a/passthrough/passthrough.go
+++ b/passthrough/passthrough.go
@@ -73,8 +73,8 @@ func NewInlinePassthroughParser(ds []delimiters) parser.InlineParser {
 
 // Determine if the input slice starts with a full valid opening delimiter.
 // If so, returns the delimiter struct, otherwise returns nil.
-func GetFullOpeningDelimiter(s *inlinePassthroughParser, line []byte) *delimiters {
-	for _, d := range s.PassthroughDelimiters {
+func GetFullOpeningDelimiter(delims []delimiters, line []byte) *delimiters {
+	for _, d := range delims {
 		if startsWith(line, d.Open) {
 			return &d
 		}
@@ -88,12 +88,16 @@ func GetFullOpeningDelimiter(s *inlinePassthroughParser, line []byte) *delimiter
 // `Parse` will be executed once for each character that is in this list of
 // allowed trigger characters. Our parse function needs to do some additional
 // checks because Trigger only works for single-byte delimiters.
-func (s *inlinePassthroughParser) Trigger() []byte {
+func OpenersFirstByte(delims []delimiters) []byte {
 	var firstBytes []byte
-	for _, d := range s.PassthroughDelimiters {
+	for _, d := range delims {
 		firstBytes = append(firstBytes, d.Open[0])
 	}
 	return firstBytes
+}
+
+func (s *inlinePassthroughParser) Trigger() []byte {
+	return OpenersFirstByte(s.PassthroughDelimiters)
 }
 
 func (s *inlinePassthroughParser) Parse(parent ast.Node, block text.Reader, pc parser.Context) ast.Node {
@@ -103,7 +107,7 @@ func (s *inlinePassthroughParser) Parse(parent ast.Node, block text.Reader, pc p
 	// of multiple triggers with parser.Context state saved between calls.
 	line, startSegment := block.PeekLine()
 
-	fencePair := GetFullOpeningDelimiter(s, line)
+	fencePair := GetFullOpeningDelimiter(s.PassthroughDelimiters, line)
 	// fencePair == nil can happen if only the first byte of an opening delimiter
 	// matches, but it is not the complete opening delimiter. The trigger causes
 	// this Parse function to execute, but the trigger interface is limited to
@@ -133,6 +137,10 @@ func (s *inlinePassthroughParser) Parse(parent ast.Node, block text.Reader, pc p
 		// This segment spans from the original starting trigger (including the delimiter)
 		// up to and including the closing delimiter.
 		seg := startSegment.WithStop(lineSegment.Start + closingDelimiterPos + len(fencePair.Close))
+		if seg.Len() == len(fencePair.Open)+len(fencePair.Close) {
+			return nil
+		}
+
 		block.Advance(closingDelimiterPos + len(fencePair.Close))
 		return NewPassthroughInline(seg)
 	}
@@ -148,24 +156,161 @@ func (r *passthroughInlineRenderer) renderRawInline(w util.BufWriter, source []b
 	return ast.WalkContinue, nil
 }
 
+// ---- Block Parser ----
+
+// A PassthroughBlock struct represents a fenced block of raw text to pass
+// through unchanged.
+// There is no built-in "raw text block" node in goldmark, and the closest
+// thing is a code block, which emits `<pre><code>` tags. So we need a new
+// node and a new block renderer.
+type PassthroughBlock struct {
+	ast.BaseBlock
+}
+
+// Dump implements Node.Dump.
+func (n *PassthroughBlock) Dump(source []byte, level int) {
+	ast.DumpHelper(n, source, level, nil, nil)
+}
+
+// KindPassthroughBlock is a NodeKind of the PassthroughBlock node.
+var KindPassthroughBlock = ast.NewNodeKind("PassthroughBlock")
+
+// Kind implements Node.Kind.
+func (n *PassthroughBlock) Kind() ast.NodeKind {
+	return KindPassthroughBlock
+}
+
+// NewPassthroughBlock return a new PassthroughBlock node.
+func NewPassthroughBlock() *PassthroughBlock {
+	return &PassthroughBlock{
+		BaseBlock: ast.BaseBlock{},
+	}
+}
+
+// Block parsing happens across different interface methods, and the initial
+// Open detects the fence pair to use by its opening delimiter. This needs to
+// be preserved for the Continue and Close methods to have access to the
+// corresponding closing delimiter.
+var passthroughParserStateKey = parser.NewContextKey()
+
+type passthroughParserState struct {
+	DetectedDelimiters *delimiters
+}
+
+type blockPassthroughParser struct {
+	PassthroughDelimiters []delimiters
+}
+
+// Implements parserWithDelimiters for blockPassthroughParser
+func (b *blockPassthroughParser) delimiters() []delimiters {
+	return b.PassthroughDelimiters
+}
+
+func NewBlockPassthroughParser(ds []delimiters) parser.BlockParser {
+	return &blockPassthroughParser{
+		PassthroughDelimiters: ds,
+	}
+}
+
+func (b *blockPassthroughParser) Trigger() []byte {
+	return OpenersFirstByte(b.PassthroughDelimiters)
+}
+
+func (b *blockPassthroughParser) Open(parent ast.Node, reader text.Reader, pc parser.Context) (ast.Node, parser.State) {
+	line, segment := reader.PeekLine()
+	fencePair := GetFullOpeningDelimiter(b.PassthroughDelimiters, line)
+	// fencePair == nil can happen if only the first byte of an opening delimiter
+	// matches, but it is not the complete opening delimiter.
+	if fencePair == nil {
+		return nil, parser.NoChildren
+	}
+	node := NewPassthroughBlock()
+	pc.Set(passthroughParserStateKey, &passthroughParserState{DetectedDelimiters: fencePair})
+
+	node.Lines().Append(segment)
+	reader.Advance(segment.Len() - 1)
+	return node, parser.NoChildren
+}
+
+func (b *blockPassthroughParser) Continue(node ast.Node, reader text.Reader, pc parser.Context) parser.State {
+	// currentState cannot be nil or else Continue was triggered without Open
+	// successfully creating a new node.
+	currentState := pc.Get(passthroughParserStateKey).(*passthroughParserState)
+	fencePair := currentState.DetectedDelimiters
+	line, segment := reader.PeekLine()
+
+	closingDelimiterPos := bytes.Index(line, []byte(fencePair.Close))
+	if closingDelimiterPos == -1 { // no closer on this line
+		node.Lines().Append(segment)
+		reader.Advance(segment.Len() - 1)
+		return parser.Continue | parser.NoChildren
+	}
+
+	// This segment spans up to and including the closing delimiter.
+	seg := segment.WithStop(segment.Start + closingDelimiterPos + len(fencePair.Close))
+	node.Lines().Append(seg)
+	reader.Advance(closingDelimiterPos + len(fencePair.Close))
+
+	return parser.Close
+}
+
+func (b *blockPassthroughParser) Close(node ast.Node, reader text.Reader, pc parser.Context) {
+}
+
+func (b *blockPassthroughParser) CanInterruptParagraph() bool {
+	return false
+}
+
+func (b *blockPassthroughParser) CanAcceptIndentedLine() bool {
+	return true
+}
+
+type passthroughBlockRenderer struct {
+}
+
+func (r *passthroughBlockRenderer) renderRawBlock(w util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
+	if entering {
+		l := n.Lines().Len()
+		for i := 0; i < l; i++ {
+			line := n.Lines().At(i)
+			w.WriteString(string(line.Value(source)))
+		}
+		w.WriteString("\n")
+	}
+	return ast.WalkSkipChildren, nil
+}
+
 // RegisterFuncs implements renderer.NodeRenderer.RegisterFuncs.
 func (r *passthroughInlineRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
 	reg.Register(KindPassthroughInline, r.renderRawInline)
+}
+
+// RegisterFuncs implements renderer.NodeRenderer.RegisterFuncs.
+func (r *passthroughBlockRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(KindPassthroughBlock, r.renderRawBlock)
 }
 
 func NewPassthroughInlineRenderer() renderer.NodeRenderer {
 	return &passthroughInlineRenderer{}
 }
 
+func NewPassthroughBlockRenderer() renderer.NodeRenderer {
+	return &passthroughBlockRenderer{}
+}
+
 // ---- Extension and config ----
 
 type passthrough struct {
 	InlineDelimiters []delimiters
+	BlockDelimiters  []delimiters
 }
 
-func NewPassthroughWithDelimiters(Delimiters []delimiters) goldmark.Extender {
+func NewPassthroughWithDelimiters(
+	InlineDelimiters []delimiters,
+	BlockDelimiters []delimiters) goldmark.Extender {
 	return &passthrough{
-		InlineDelimiters: Delimiters,
+		InlineDelimiters: InlineDelimiters,
+		BlockDelimiters:  BlockDelimiters,
 	}
 }
 
@@ -174,9 +319,13 @@ func (e *passthrough) Extend(m goldmark.Markdown) {
 		parser.WithInlineParsers(
 			util.Prioritized(NewInlinePassthroughParser(e.InlineDelimiters), 201),
 		),
+		parser.WithBlockParsers(
+			util.Prioritized(NewBlockPassthroughParser(e.BlockDelimiters), 99),
+		),
 	)
 
 	m.Renderer().AddOptions(renderer.WithNodeRenderers(
 		util.Prioritized(NewPassthroughInlineRenderer(), 101),
+		util.Prioritized(NewPassthroughBlockRenderer(), 99),
 	))
 }

--- a/passthrough/passthrough.go
+++ b/passthrough/passthrough.go
@@ -236,16 +236,16 @@ type passthroughBlockRenderer struct {
 
 func (r *passthroughBlockRenderer) renderRawBlock(w util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
-    w.WriteString("\n")
+		w.WriteString("\n")
 		l := n.Lines().Len()
 		for i := 0; i < l; i++ {
 			line := n.Lines().At(i)
 			w.WriteString(string(line.Value(source)))
 		}
-    w.WriteString("\n")
+		w.WriteString("\n")
 	} else {
-    w.WriteString("\n")
-  }
+		w.WriteString("\n")
+	}
 	return ast.WalkContinue, nil
 }
 

--- a/passthrough/passthrough_test.go
+++ b/passthrough/passthrough_test.go
@@ -1,12 +1,118 @@
 package passthrough
 
 import (
+	"bytes"
+	"strings"
 	"testing"
+
+	"github.com/yuin/goldmark"
 
 	qt "github.com/frankban/quicktest"
 )
 
-func TestFoo(t *testing.T) {
+func buildTestParser() goldmark.Markdown {
+	md := goldmark.New(
+		goldmark.WithExtensions(NewPassthroughWithDelimiters(
+			/*inlines*/ []delimiters{
+				{
+					Open:  "$",
+					Close: "$",
+				},
+				{
+					Open:  "\\(",
+					Close: "\\)",
+				},
+			},
+			/*blocks*/ []delimiters{
+				{
+					Open:  "$$",
+					Close: "$$",
+				},
+				{
+					Open:  "\\[",
+					Close: "\\[",
+				},
+			},
+		)),
+	)
+	return md
+}
+
+func Parse(t *testing.T, input string) string {
+	md := buildTestParser()
+	var buf bytes.Buffer
+	if err := md.Convert([]byte(input), &buf); err != nil {
+		t.Fatal(err)
+	}
+	return strings.TrimSpace(buf.String())
+}
+
+func TestEmphasisOutsideOfMathmode(t *testing.T) {
+	input := "Emph: _wow_"
+	expected := "<p>Emph: <em>wow</em></p>"
+	actual := Parse(t, input)
+
 	c := qt.New(t)
-	c.Assert(Foo(), qt.Equals, "foo")
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestInlineEquationWithEmphasisDelimiters(t *testing.T) {
+	input := "An equation: $a^*=x-b^*$. Amazing"
+	expected := "<p>An equation: $a^*=x-b^*$. Amazing</p>"
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestInlineEquationWithMultiByteDelimiters(t *testing.T) {
+	input := "An equation: \\(a^*=x-b^*\\). Amazing"
+	expected := "<p>An equation: \\(a^*=x-b^*\\). Amazing</p>"
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestInlineEquationWithEmphasisDelimitersSplitAcrossLines(t *testing.T) {
+	input := `An equation: $a^*=
+x-b^*$. Amazing`
+	expected := `<p>An equation: $a^*=
+x-b^*$. Amazing</p>`
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestInlineEquationWithEmphasisSplitAcrossParagraphs(t *testing.T) {
+	input := `An equation: $a^
+
+*=x-b^*$. Amazing`
+	expected := `<p>An equation: $a^</p>
+<p><em>=x-b^</em>$. Amazing</p>`
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestBlockEquationWithEmphasisDelimiters(t *testing.T) {
+	input := `An equation:
+
+$$
+a^*=x-b^*
+$$
+
+Amazing`
+	expected := `<p>An equation:</p>
+<p>$$
+a^*=x-b^*
+$$</p>
+<p>Amazing</p>`
+
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
 }

--- a/passthrough/passthrough_test.go
+++ b/passthrough/passthrough_test.go
@@ -160,6 +160,14 @@ func TestUnterminatedDelimiters(t *testing.T) {
 	c.Assert(actual, qt.Equals, expected)
 }
 
+func TestEscapedSingleByteDelimiter(t *testing.T) {
+	input := `I want \\$ *dollars*: $a^*=x-b^*$ Amazing.`
+	expected := `<p>I want \$ <em>dollars</em>: $a^*=x-b^*$ Amazing.</p>`
+	actual := Parse(t, input)
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
 func TestFirstByteOfMultiByteDelimiterEndsText(t *testing.T) {
 	input := `An equation: \`
 	expected := `<p>An equation: \</p>`

--- a/passthrough/passthrough_test.go
+++ b/passthrough/passthrough_test.go
@@ -448,7 +448,7 @@ func TestExample25(t *testing.T) {
 \end{array}
 $$`
 
-	expected := input
+	expected := "<p>" + input + "</p>"
 	actual := Parse(t, input)
 
 	c := qt.New(t)
@@ -474,7 +474,7 @@ func TestExample26(t *testing.T) {
  \end{array}
  \]`
 
-	expected := input
+	expected := "<p>" + input + "</p>"
 	actual := Parse(t, input)
 
 	c := qt.New(t)

--- a/passthrough/passthrough_test.go
+++ b/passthrough/passthrough_test.go
@@ -187,8 +187,9 @@ func TestExample1(t *testing.T) {
 }
 
 func TestExample2(t *testing.T) {
-	input := `x = {-b \pm \sqrt{b^2-4ac} \over 2a}
-n$ equation`
+	input := `Inline $
+x = {-b \pm \sqrt{b^2-4ac} \over 2a}
+$ equation`
 
 	expected := "<p>" + input + "</p>"
 	actual := Parse(t, input)
@@ -482,22 +483,22 @@ $$`
 
 func TestExample26(t *testing.T) {
 	input := `\[
- \begin{array} {lcl}
- 	L(p,w_i) &=& \dfrac{1}{N}\Sigma_{i=1}^N(\underbrace{f_r(x_2
- 	\rightarrow x_1
- 	\rightarrow x_0)G(x_1
- 	\longleftrightarrow x_2)f_r(x_3
- 	\rightarrow x_2
- 	\rightarrow x_1)}_{sample\, radiance\, evaluation\, in\, stage2}
- 	\\\\\\ &=&
- 	\prod_{i=3}^{k-1}(\underbrace{\dfrac{f_r(x_{i+1}
- 	\rightarrow x_i
- 	\rightarrow x_{i-1})G(x_i
- 	\longleftrightarrow x_{i-1})}{p_a(x_{i-1})}}_{stored\,in\,vertex\, during\,light\, path\, tracing\, in\, stage1})\dfrac{G(x_k
- 	\longleftrightarrow x_{k-1})L_e(x_k
- 	\rightarrow x_{k-1})}{p_a(x_{k-1})p_a(x_k)})
- \end{array}
- \]`
+\begin{array} {lcl}
+L(p,w_i) &=& \dfrac{1}{N}\Sigma_{i=1}^N(\underbrace{f_r(x_2
+\rightarrow x_1
+\rightarrow x_0)G(x_1
+\longleftrightarrow x_2)f_r(x_3
+\rightarrow x_2
+\rightarrow x_1)}_{sample\, radiance\, evaluation\, in\, stage2}
+\\\\\\ &=&
+\prod_{i=3}^{k-1}(\underbrace{\dfrac{f_r(x_{i+1}
+\rightarrow x_i
+\rightarrow x_{i-1})G(x_i
+\longleftrightarrow x_{i-1})}{p_a(x_{i-1})}}_{stored\,in\,vertex\, during\,light\, path\, tracing\, in\, stage1})\dfrac{G(x_k
+\longleftrightarrow x_{k-1})L_e(x_k
+\rightarrow x_{k-1})}{p_a(x_{k-1})p_a(x_k)})
+\end{array}
+\]`
 
 	expected := input
 	actual := Parse(t, input)

--- a/passthrough/passthrough_test.go
+++ b/passthrough/passthrough_test.go
@@ -15,6 +15,7 @@ func buildTestParser() goldmark.Markdown {
 	md := goldmark.New(
 		goldmark.WithExtensions(NewPassthroughWithDelimiters(
 			/*inline*/ []delimiters{
+        // FIXME: remove block delimiters from this config
 				{
 					Open:  "$$",
 					Close: "$$",
@@ -221,10 +222,10 @@ x = {-b \pm \sqrt{b^2-4ac} \over 2a}$ equation`
 
 func TestExample5(t *testing.T) {
 	input := `Block $$x = {-b \pm \sqrt{b^2-4ac} \over 2a}$$ equation`
-
-	expected := "<p>" + input + "</p>"
+	expected := `<p>Block </p>
+$$x = {-b \pm \sqrt{b^2-4ac} \over 2a}$$
+<p> equation</p>`
 	actual := Parse(t, input)
-
 	c := qt.New(t)
 	c.Assert(actual, qt.Equals, expected)
 }
@@ -233,10 +234,12 @@ func TestExample6(t *testing.T) {
 	input := `Block $$
 x = {-b \pm \sqrt{b^2-4ac} \over 2a}
 $$ equation`
-
-	expected := "<p>" + input + "</p>"
+	expected := `<p>Block </p>
+$$
+x = {-b \pm \sqrt{b^2-4ac} \over 2a}
+$$
+<p> equation</p>`
 	actual := Parse(t, input)
-
 	c := qt.New(t)
 	c.Assert(actual, qt.Equals, expected)
 }
@@ -244,8 +247,10 @@ $$ equation`
 func TestExample7(t *testing.T) {
 	input := `Block $$x = {-b \pm \sqrt{b^2-4ac} \over 2a}
 $$ equation`
-
-	expected := "<p>" + input + "</p>"
+	expected := `<p>Block </p>
+$$x = {-b \pm \sqrt{b^2-4ac} \over 2a}
+$$
+<p> equation</p>`
 	actual := Parse(t, input)
 
 	c := qt.New(t)
@@ -255,8 +260,10 @@ $$ equation`
 func TestExample8(t *testing.T) {
 	input := `Block $$
 x = {-b \pm \sqrt{b^2-4ac} \over 2a}$$ equation`
-
-	expected := "<p>" + input + "</p>"
+	expected := `<p>Block </p>
+$$
+x = {-b \pm \sqrt{b^2-4ac} \over 2a}$$
+<p> equation</p>`
 	actual := Parse(t, input)
 
 	c := qt.New(t)
@@ -309,10 +316,10 @@ a^*=x-b^*$ equation`
 
 func TestExample13(t *testing.T) {
 	input := `Block $$a^*=x-b^*$$ equation`
-
-	expected := "<p>" + input + "</p>"
+	expected := `<p>Block </p>
+$$a^*=x-b^*$$
+<p> equation</p>`
 	actual := Parse(t, input)
-
 	c := qt.New(t)
 	c.Assert(actual, qt.Equals, expected)
 }
@@ -321,10 +328,12 @@ func TestExample14(t *testing.T) {
 	input := `Block $$
 a^*=x-b^*
 $$ equation`
-
-	expected := "<p>" + input + "</p>"
+	expected := `<p>Block </p>
+$$
+a^*=x-b^*
+$$
+<p> equation</p>`
 	actual := Parse(t, input)
-
 	c := qt.New(t)
 	c.Assert(actual, qt.Equals, expected)
 }
@@ -332,10 +341,11 @@ $$ equation`
 func TestExample15(t *testing.T) {
 	input := `Block $$a^*=x-b^*
 $$ equation`
-
-	expected := "<p>" + input + "</p>"
+	expected := `<p>Block </p>
+$$a^*=x-b^*
+$$
+<p> equation</p>`
 	actual := Parse(t, input)
-
 	c := qt.New(t)
 	c.Assert(actual, qt.Equals, expected)
 }
@@ -343,10 +353,11 @@ $$ equation`
 func TestExample16(t *testing.T) {
 	input := `Block $$
 a^*=x-b^*$$ equation`
-
-	expected := "<p>" + input + "</p>"
+	expected := `<p>Block </p>
+$$
+a^*=x-b^*$$
+<p> equation</p>`
 	actual := Parse(t, input)
-
 	c := qt.New(t)
 	c.Assert(actual, qt.Equals, expected)
 }
@@ -397,10 +408,10 @@ a^*=x-b^*\) equation`
 
 func TestExample21(t *testing.T) {
 	input := `Block \[a^*=x-b^*\] equation`
-
-	expected := "<p>" + input + "</p>"
+	expected := `<p>Block </p>
+\[a^*=x-b^*\]
+<p> equation</p>`
 	actual := Parse(t, input)
-
 	c := qt.New(t)
 	c.Assert(actual, qt.Equals, expected)
 }
@@ -409,21 +420,24 @@ func TestExample22(t *testing.T) {
 	input := `Block \[
 a^*=x-b^*
 \] equation`
-
-	expected := "<p>" + input + "</p>"
+	expected := `<p>Block </p>
+\[
+a^*=x-b^*
+\]
+<p> equation</p>`
 	actual := Parse(t, input)
-
 	c := qt.New(t)
 	c.Assert(actual, qt.Equals, expected)
 }
 
 func TestExample23(t *testing.T) {
 	input := `Block \[a^*=x-b^*
-	\] equation`
-
-	expected := "<p>" + input + "</p>"
+\] equation`
+	expected := `<p>Block </p>
+\[a^*=x-b^*
+\]
+<p> equation</p>`
 	actual := Parse(t, input)
-
 	c := qt.New(t)
 	c.Assert(actual, qt.Equals, expected)
 }
@@ -431,8 +445,10 @@ func TestExample23(t *testing.T) {
 func TestExample24(t *testing.T) {
 	input := `Block \[
 a^*=x-b^*\] equation`
-
-	expected := "<p>" + input + "</p>"
+	expected := `<p>Block </p>
+\[
+a^*=x-b^*\]
+<p> equation</p>`
 	actual := Parse(t, input)
 
 	c := qt.New(t)

--- a/passthrough/passthrough_test.go
+++ b/passthrough/passthrough_test.go
@@ -76,7 +76,7 @@ func TestDump(t *testing.T) {
 	md := buildTestParser()
 	root := md.Parser().Parse(text.NewReader([]byte(input)))
 	root.Dump([]byte(input), 0)
-  // Prints to stdout, so just test that it doesn't crash
+	// Prints to stdout, so just test that it doesn't crash
 }
 
 func TestInlineEquationWithEmphasisDelimitersSplitAcrossLines(t *testing.T) {

--- a/passthrough/passthrough_test.go
+++ b/passthrough/passthrough_test.go
@@ -14,9 +14,7 @@ import (
 func buildTestParser() goldmark.Markdown {
 	md := goldmark.New(
 		goldmark.WithExtensions(NewPassthroughWithDelimiters(
-			[]delimiters{
-				// $$ is more specific than $, and so it has to come first
-				// or else the parser will match $$ as an empty segment.
+			/*inline*/ []delimiters{
 				{
 					Open:  "$$",
 					Close: "$$",
@@ -34,6 +32,16 @@ func buildTestParser() goldmark.Markdown {
 					Close: "\\)",
 				},
 			},
+			/*block*/ []delimiters{
+				{
+					Open:  "$$",
+					Close: "$$",
+				},
+				{
+					Open:  "\\[",
+					Close: "\\]",
+				},
+			},
 		)),
 	)
 	return md
@@ -43,7 +51,6 @@ func Parse(t *testing.T, input string) string {
 	md := buildTestParser()
 	var buf bytes.Buffer
 
-	// For debugging: add import of goldmark/text
 	// root := md.Parser().Parse(text.NewReader([]byte(input)))
 	// root.Dump([]byte(input), 0)
 
@@ -124,9 +131,9 @@ $$
 
 Amazing`
 	expected := `<p>An equation:</p>
-<p>$$
+$$
 a^*=x-b^*
-$$</p>
+$$
 <p>Amazing</p>`
 
 	actual := Parse(t, input)
@@ -143,8 +150,8 @@ $$a^*=x-b^*
 
 Amazing`
 	expected := `<p>An equation:</p>
-<p>$$a^*=x-b^*
-=c$$</p>
+$$a^*=x-b^*
+=c$$
 <p>Amazing</p>`
 
 	actual := Parse(t, input)
@@ -451,7 +458,7 @@ func TestExample25(t *testing.T) {
 \end{array}
 $$`
 
-	expected := "<p>" + input + "</p>"
+	expected := input
 	actual := Parse(t, input)
 
 	c := qt.New(t)
@@ -477,7 +484,7 @@ func TestExample26(t *testing.T) {
  \end{array}
  \]`
 
-	expected := "<p>" + input + "</p>"
+	expected := input
 	actual := Parse(t, input)
 
 	c := qt.New(t)

--- a/passthrough/passthrough_test.go
+++ b/passthrough/passthrough_test.go
@@ -14,7 +14,7 @@ import (
 func buildTestParser() goldmark.Markdown {
 	md := goldmark.New(
 		goldmark.WithExtensions(NewPassthroughWithDelimiters(
-			/*inline*/ []delimiters{
+			/*inline*/ []Delimiters{
 				{
 					Open:  "$",
 					Close: "$",
@@ -24,7 +24,7 @@ func buildTestParser() goldmark.Markdown {
 					Close: "\\)",
 				},
 			},
-			/*block*/ []delimiters{
+			/*block*/ []Delimiters{
 				{
 					Open:  "$$",
 					Close: "$$",
@@ -503,6 +503,18 @@ L(p,w_i) &=& \dfrac{1}{N}\Sigma_{i=1}^N(\underbrace{f_r(x_2
 	expected := input
 	actual := Parse(t, input)
 
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestRepeatedBlockNodesInOneParagraph(t *testing.T) {
+	input := `Block $$x$$ equation $$y$$.`
+	expected := `<p>Block </p>
+$$x$$
+<p> equation </p>
+$$y$$
+<p>.</p>`
+	actual := Parse(t, input)
 	c := qt.New(t)
 	c.Assert(actual, qt.Equals, expected)
 }

--- a/passthrough/passthrough_test.go
+++ b/passthrough/passthrough_test.go
@@ -106,10 +106,45 @@ $$
 
 Amazing`
 	expected := `<p>An equation:</p>
-<p>$$
+
+$$
 a^*=x-b^*
-$$</p>
+$$
+
 <p>Amazing</p>`
+
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestBlockEquationWithOpenAndCloseOnSameLines(t *testing.T) {
+	input := `An equation:
+
+$$a^*=x-b^*
+=c$$
+
+Amazing`
+	expected := `<p>An equation:</p>
+
+$$a^*=x-b^*
+=c$$
+
+<p>Amazing</p>`
+
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestBlockEquationBreakingParagraph(t *testing.T) {
+  input := `An equation: \\[a^*=x-b^*\\] Amazing.`
+	// This one is treated as inline because, for whatever reason, the block
+	// parser is never triggered, even though we set CanInterruptParagraph to be
+	// true. Hence it does not trigger and gets mangled as normal.
+	expected := `<p>An equation: \[a^<em>=x-b^</em>\] Amazing.</p>`
 
 	actual := Parse(t, input)
 

--- a/passthrough/passthrough_test.go
+++ b/passthrough/passthrough_test.go
@@ -202,14 +202,338 @@ func TestMassiveEquationSquareDelimiters(t *testing.T) {
 	c.Assert(actual, qt.Equals, expected)
 }
 
-
 func TestBlockEquationBreakingParagraph(t *testing.T) {
-  input := `An equation: \\[a^*=x-b^*\\] Amazing.`
+	input := `An equation: \\[a^*=x-b^*\\] Amazing.`
 	// This one is treated as inline because, for whatever reason, the block
 	// parser is never triggered, even though we set CanInterruptParagraph to be
 	// true. Hence it does not trigger and gets mangled as normal.
 	expected := `<p>An equation: \[a^<em>=x-b^</em>\] Amazing.</p>`
 
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestExample1(t *testing.T) {
+	input := `Inline $x = {-b \pm \sqrt{b^2-4ac} \over 2a}$ equation`
+
+	expected := "<p>" + input + "</p>"
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestExample2(t *testing.T) {
+	input := `x = {-b \pm \sqrt{b^2-4ac} \over 2a}
+n$ equation`
+
+	expected := "<p>" + input + "</p>"
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestExample3(t *testing.T) {
+	input := `Inline $x = {-b \pm \sqrt{b^2-4ac} \over 2a}
+$ equation`
+
+	expected := "<p>" + input + "</p>"
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestExample4(t *testing.T) {
+	input := `Inline $
+x = {-b \pm \sqrt{b^2-4ac} \over 2a}$ equation`
+
+	expected := "<p>" + input + "</p>"
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestExample5(t *testing.T) {
+	input := `Block $$x = {-b \pm \sqrt{b^2-4ac} \over 2a}$$ equation`
+
+	expected := "<p>" + input + "</p>"
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestExample6(t *testing.T) {
+	input := `Block $$
+x = {-b \pm \sqrt{b^2-4ac} \over 2a}
+$$ equation`
+
+	expected := "<p>" + input + "</p>"
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Skip() // TODO failing test
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestExample7(t *testing.T) {
+	input := `Block $$x = {-b \pm \sqrt{b^2-4ac} \over 2a}
+$$ equation`
+
+	expected := "<p>" + input + "</p>"
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Skip() // TODO failing test
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestExample8(t *testing.T) {
+	input := `Block $$
+x = {-b \pm \sqrt{b^2-4ac} \over 2a}$$ equation`
+
+	expected := "<p>" + input + "</p>"
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestExample9(t *testing.T) {
+	input := `Inline $a^*=x-b^*$ equation`
+
+	expected := "<p>" + input + "</p>"
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestExample10(t *testing.T) {
+	input := `Inline $
+a^*=x-b^*
+$ equation`
+
+	expected := "<p>" + input + "</p>"
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestExample11(t *testing.T) {
+	input := `Inline $a^*=x-b^*
+$ equation`
+
+	expected := "<p>" + input + "</p>"
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestExample12(t *testing.T) {
+	input := `Inline $
+a^*=x-b^*$ equation`
+
+	expected := "<p>" + input + "</p>"
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestExample13(t *testing.T) {
+	input := `Block $$a^*=x-b^*$$ equation`
+
+	expected := "<p>" + input + "</p>"
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Skip() // TODO failing test
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestExample14(t *testing.T) {
+	input := `Block $$
+a^*=x-b^*
+$$ equation`
+
+	expected := "<p>" + input + "</p>"
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Skip() // TODO failing test
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestExample15(t *testing.T) {
+	input := `Block $$a^*=x-b^*
+$$ equation`
+
+	expected := "<p>" + input + "</p>"
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Skip() // TODO failing test
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestExample16(t *testing.T) {
+	input := `Block $$
+a^*=x-b^*$$ equation`
+
+	expected := "<p>" + input + "</p>"
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Skip() // TODO failing test
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestExample17(t *testing.T) {
+	input := `Inline \(a^*=x-b^*\) equation`
+
+	expected := "<p>" + input + "</p>"
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestExample18(t *testing.T) {
+	input := `Inline \(
+a^*=x-b^*
+\) equation`
+
+	expected := "<p>" + input + "</p>"
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestExample19(t *testing.T) {
+	input := `Inline \(a^*=x-b^*
+\) equation`
+
+	expected := "<p>" + input + "</p>"
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestExample20(t *testing.T) {
+	input := `Inline \(
+a^*=x-b^*\) equation`
+
+	expected := "<p>" + input + "</p>"
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestExample21(t *testing.T) {
+	input := `Block \[a^*=x-b^*\] equation`
+
+	expected := "<p>" + input + "</p>"
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Skip() // TODO failing test
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestExample22(t *testing.T) {
+	input := `Block \[
+a^*=x-b^*
+\] equation`
+
+	expected := "<p>" + input + "</p>"
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Skip() // TODO failing test
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestExample23(t *testing.T) {
+	input := `Block \[a^*=x-b^*
+	\] equation`
+
+	expected := "<p>" + input + "</p>"
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Skip() // TODO failing test
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestExample24(t *testing.T) {
+	input := `Block \[
+a^*=x-b^*\] equation`
+
+	expected := "<p>" + input + "</p>"
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Skip() // TODO failing test
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestExample25(t *testing.T) {
+	input := `$$
+\begin{array} {lcl}
+	L(p,w_i) &=& \dfrac{1}{N}\Sigma_{i=1}^N(\underbrace{f_r(x_2
+	\rightarrow x_1
+	\rightarrow x_0)G(x_1
+	\longleftrightarrow x_2)f_r(x_3
+	\rightarrow x_2
+	\rightarrow x_1)}_{sample\, radiance\, evaluation\, in\, stage2}
+	\\\\\\ &=&
+	\prod_{i=3}^{k-1}(\underbrace{\dfrac{f_r(x_{i+1}
+	\rightarrow x_i
+	\rightarrow x_{i-1})G(x_i
+	\longleftrightarrow x_{i-1})}{p_a(x_{i-1})}}_{stored\,in\,vertex\, during\,light\, path\, tracing\, in\, stage1})\dfrac{G(x_k
+	\longleftrightarrow x_{k-1})L_e(x_k
+	\rightarrow x_{k-1})}{p_a(x_{k-1})p_a(x_k)})
+\end{array}
+$$`
+
+	expected := input
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestExample26(t *testing.T) {
+	input := `\[
+\begin{array} {lcl}
+	L(p,w_i) &=& \dfrac{1}{N}\Sigma_{i=1}^N(\underbrace{f_r(x_2
+	\rightarrow x_1
+	\rightarrow x_0)G(x_1
+	\longleftrightarrow x_2)f_r(x_3
+	\rightarrow x_2
+	\rightarrow x_1)}_{sample\, radiance\, evaluation\, in\, stage2}
+	\\\\\\ &=&
+	\prod_{i=3}^{k-1}(\underbrace{\dfrac{f_r(x_{i+1}
+	\rightarrow x_i
+	\rightarrow x_{i-1})G(x_i
+	\longleftrightarrow x_{i-1})}{p_a(x_{i-1})}}_{stored\,in\,vertex\, during\,light\, path\, tracing\, in\, stage1})\dfrac{G(x_k
+	\longleftrightarrow x_{k-1})L_e(x_k
+	\rightarrow x_{k-1})}{p_a(x_{k-1})p_a(x_k)})
+\end{array}
+\]`
+
+	expected := input
 	actual := Parse(t, input)
 
 	c := qt.New(t)

--- a/passthrough/passthrough_test.go
+++ b/passthrough/passthrough_test.go
@@ -15,15 +15,6 @@ func buildTestParser() goldmark.Markdown {
 	md := goldmark.New(
 		goldmark.WithExtensions(NewPassthroughWithDelimiters(
 			/*inline*/ []delimiters{
-        // FIXME: remove block delimiters from this config
-				{
-					Open:  "$$",
-					Close: "$$",
-				},
-				{
-					Open:  "\\[",
-					Close: "\\]",
-				},
 				{
 					Open:  "$",
 					Close: "$",

--- a/passthrough/passthrough_test.go
+++ b/passthrough/passthrough_test.go
@@ -85,6 +85,19 @@ x-b^*$. Amazing</p>`
 	c.Assert(actual, qt.Equals, expected)
 }
 
+func TestInlineEquationWithEmphasisDelimitersSplitAcrossLines2(t *testing.T) {
+	input := `Inline $
+a^*=x-b^*
+$ equation`
+	expected := `<p>Inline $
+a^*=x-b^*
+$ equation</p>`
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
 func TestInlineEquationWithEmphasisSplitAcrossParagraphs(t *testing.T) {
 	input := `An equation: $a^
 
@@ -138,6 +151,57 @@ $$a^*=x-b^*
 	c := qt.New(t)
 	c.Assert(actual, qt.Equals, expected)
 }
+
+func TestMassiveEquation(t *testing.T) {
+	input := `$$
+\begin{array} {lcl}
+  L(p,w_i) &=& \dfrac{1}{N}\Sigma_{i=1}^N(\underbrace{f_r(x_2
+  \rightarrow x_1
+  \rightarrow x_0)G(x_1
+  \longleftrightarrow x_2)f_r(x_3
+  \rightarrow x_2
+  \rightarrow x_1)}_{sample\, radiance\, evaluation\, in\, stage2}
+  \\\\\\ &=&
+  \prod_{i=3}^{k-1}(\underbrace{\dfrac{f_r(x_{i+1}
+  \rightarrow x_i
+  \rightarrow x_{i-1})G(x_i
+  \longleftrightarrow x_{i-1})}{p_a(x_{i-1})}}_{stored\,in\,vertex\, during\,light\, path\, tracing\, in\, stage1})\dfrac{G(x_k
+  \longleftrightarrow x_{k-1})L_e(x_k
+  \rightarrow x_{k-1})}{p_a(x_{k-1})p_a(x_k)})
+\end{array}
+$$`
+	expected := input
+
+	actual := Parse(t, input)
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
+func TestMassiveEquationSquareDelimiters(t *testing.T) {
+	input := `\[
+\begin{array} {lcl}
+  L(p,w_i) &=& \dfrac{1}{N}\Sigma_{i=1}^N(\underbrace{f_r(x_2
+  \rightarrow x_1
+  \rightarrow x_0)G(x_1
+  \longleftrightarrow x_2)f_r(x_3
+  \rightarrow x_2
+  \rightarrow x_1)}_{sample\, radiance\, evaluation\, in\, stage2}
+  \\\\\\ &=&
+  \prod_{i=3}^{k-1}(\underbrace{\dfrac{f_r(x_{i+1}
+  \rightarrow x_i
+  \rightarrow x_{i-1})G(x_i
+  \longleftrightarrow x_{i-1})}{p_a(x_{i-1})}}_{stored\,in\,vertex\, during\,light\, path\, tracing\, in\, stage1})\dfrac{G(x_k
+  \longleftrightarrow x_{k-1})L_e(x_k
+  \rightarrow x_{k-1})}{p_a(x_{k-1})p_a(x_k)})
+\end{array}
+\]`
+	expected := input
+
+	actual := Parse(t, input)
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
 
 func TestBlockEquationBreakingParagraph(t *testing.T) {
   input := `An equation: \\[a^*=x-b^*\\] Amazing.`


### PR DESCRIPTION
Implementation is ready for review with one caveat: I can't get goldmark to trigger the block parser for inputs where the block fences are placed inline:

```
Block \[x^*=y^*\] equation
```

Despite having `CanInterruptParagraph` to true in the parser, the block parser is never triggered and I'm not sure why.

One workaround for LaTeX is to duplicate all the configured block fences in the config for the inline fences, which actually seems like the more appropriate general behavior: a configured block fence only triggers when it's the start of a new markdown paragraph.

Other than that, all the tests in `https://github.com/jmooring/hugo-testing/blob/hugo-github-issue-10894` seem to pass.