### PR TITLE
Add a basic benchmark

### DIFF
--- a/passthrough/passthrough_test.go
+++ b/passthrough/passthrough_test.go
@@ -546,3 +546,38 @@ $$a^*=x-b^*$$
 	c := qt.New(t)
 	c.Assert(actual, qt.Equals, expected)
 }
+
+func BenchmarkWithAndWithoutPassthrough(b *testing.B) {
+	const input = `
+## Block
+	
+$$
+a^*=x-b^*
+$$
+
+## Inline
+
+Inline $a^*=x-b^*$ equation.`
+
+	b.Run("without passthrough", func(b *testing.B) {
+		md := goldmark.New()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			var buf bytes.Buffer
+			if err := md.Convert([]byte(input), &buf); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("with passthrough", func(b *testing.B) {
+		md := buildTestParser()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			var buf bytes.Buffer
+			if err := md.Convert([]byte(input), &buf); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Looks fine to me:

```bash
BenchmarkWithAndWithoutPassthrough/without_passthrough-10         	  250126	      4943 ns/op	   10448 B/op	      47 allocs/op
BenchmarkWithAndWithoutPassthrough/with_passthrough-10            	  240734	      4873 ns/op	   11128 B/op	      50 allocs/op
```
