### PR TITLE
Bump checkout action to latest version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Update PATH
         run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Fmt
         if: matrix.platform != 'windows-latest'
         run: "diff <(gofmt -d .) <(printf '')"


### PR DESCRIPTION
This PR bumps `checkout` action to latest version `v4`.