### PR TITLE
passthrough: Upgrade goldmark and fix upstream regression

### DIFF
--- a/passthrough/go.mod
+++ b/passthrough/go.mod
@@ -9,5 +9,5 @@ require (
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
-	github.com/yuin/goldmark v1.7.2
+	github.com/yuin/goldmark v1.7.8
 )

--- a/passthrough/go.sum
+++ b/passthrough/go.sum
@@ -12,5 +12,5 @@ github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsK
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
-github.com/yuin/goldmark v1.7.2 h1:NjGd7lO7zrUn/A7eKwn5PEOt4ONYGqpxSEeZuduvgxc=
-github.com/yuin/goldmark v1.7.2/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=
+github.com/yuin/goldmark v1.7.8 h1:iERMLn0/QJeHFhxSt3p6PeN9mGnvIKSpG9YYorDMnic=
+github.com/yuin/goldmark v1.7.8/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=

--- a/passthrough/passthrough_test.go
+++ b/passthrough/passthrough_test.go
@@ -567,6 +567,24 @@ $$a^*=x-b^*$$
 	c.Assert(actual, qt.Equals, expected)
 }
 
+func TestIssue32(t *testing.T) {
+	input := `line one
+$$ a^n + b^n = c^n $$
+line two`
+
+	// The mid-paragraph new lines are undesirable, but this is how it worked
+	// with Goldmark v1.7.4.
+	expected := `<p>line one
+</p>
+$$ a^n + b^n = c^n $$
+<p>
+line two</p>`
+	actual := Parse(t, input)
+
+	c := qt.New(t)
+	c.Assert(actual, qt.Equals, expected)
+}
+
 func TestNodeDelimiter(t *testing.T) {
 	input := `
 Block $$a^*=x-b^*$$ equation


### PR DESCRIPTION
Goldmark v1.7.5 changed the default behaviour of the BaseBlock.Text() function, breaking the block transformer for block math. Later, in Goldmark v1.7.8, the whole Text() function was deprecated. 

This PR also deprecates PassthroughInline.Text() and removes all calls for Node.Text(), fixing the regression.

Fixes #32 