### PR TITLE
Update Go 1.24.x/1.25.x, GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.25.x, 1.26.x]
+        go-version: [1.24.x, 1.25.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
         package: [passthrough, extras]
     runs-on: ${{ matrix.platform }}
@@ -16,7 +16,7 @@ jobs:
         shell: bash
     steps:
       - name: Install Go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version: ${{ matrix.go-version }}
           cache: false
@@ -26,7 +26,7 @@ jobs:
       - name: Update PATH
         run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
       - name: Checkout code
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Fmt
         if: matrix.platform != 'windows-latest'
         run: "diff <(gofmt -d .) <(printf '')"


### PR DESCRIPTION
Updates: Go 1.24.x/1.25.x, GitHub Actions

---
Created by mygithelper