### PR TITLE
ci: declare contents:read on test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@ on:
     branches: [main]
   pull_request:
 name: Test
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Adds `permissions: contents: read` at the top of `.github/workflows/test.yml`. The matrix job sets up Go (across macOS/Linux/Windows runners), checks out the repo, and runs `go test`. No part of the chain calls a GitHub API beyond the initial checkout.

The reason to be explicit even when the inherited default is likely already read-only is CVE-2025-30066 (the March 2025 `tj-actions/changed-files` supply-chain compromise) - a tampered third-party action exfiltrated `GITHUB_TOKEN` from workflow logs and the leaked token retained whatever scope was issued. Per-workflow caps bound the runtime authority of every action that runs inside the workflow, irrespective of repo or org default. The block also gives drift protection if the default ever widens and registers with OpenSSF Scorecard's Token-Permissions check.

YAML validated locally with `yaml.safe_load`.
